### PR TITLE
Query providers examples

### DIFF
--- a/examples/details_of_single_provider.ts
+++ b/examples/details_of_single_provider.ts
@@ -1,0 +1,16 @@
+import { QueryClientImpl, QueryProviderRequest, QueryProviderResponse } from "@akashnetwork/akashjs/build/protobuf/akash/provider/v1beta2/query";
+import { getRpc } from "@akashnetwork/akashjs/build/rpc"
+
+async function main() {
+    const client = new QueryClientImpl(await getRpc("http://your.rpc.node"));
+    
+    const getProviderInfoRequest = QueryProviderRequest.fromPartial({
+        owner: "akashSomeProviderAddress"
+    })
+    const providerResponse = await client.Provider(getProviderInfoRequest);
+    const data = QueryProviderResponse.toJSON(providerResponse);
+    
+    console.log(data)
+}
+
+main();

--- a/examples/get_lease_status.ts
+++ b/examples/get_lease_status.ts
@@ -1,0 +1,23 @@
+import { QueryClientImpl, QueryLeaseRequest, QueryLeaseResponse} from "@akashnetwork/akashjs/build/protobuf/akash/market/v1beta2/query";
+import { getRpc } from "@akashnetwork/akashjs/build/rpc"
+
+async function main() {
+    const client = new QueryClientImpl(await getRpc("http://your.rpc.node"));
+    
+    const getLeaseStatusRequest = QueryLeaseRequest.fromPartial({
+        id: {
+            owner: "akashSomeOwnerAddress",
+            provider: "akashSomeProviderAddress",
+            dseq: 1111, // deployment dseq 
+            gseq: 1, // most of the time the value is 1
+            oseq: 1 // most of the time the value is 1
+        }
+    })
+
+    const leaseStatusResponse = await client.Lease(getLeaseStatusRequest);
+    const data = QueryLeaseResponse.toJSON(leaseStatusResponse);
+    
+    console.log(data)
+}
+
+main();

--- a/examples/list_all_providers.ts
+++ b/examples/list_all_providers.ts
@@ -1,0 +1,19 @@
+import { QueryClientImpl, QueryProvidersRequest, QueryProvidersResponse } from "@akashnetwork/akashjs/build/protobuf/akash/provider/v1beta2/query";
+import { getRpc } from "@akashnetwork/akashjs/build/rpc"
+
+async function main() {
+    const client = new QueryClientImpl(await getRpc("http://your.rpc.node"));
+
+    const providersRequest = QueryProvidersRequest.fromPartial({
+        pagination: {
+            limit: 100, //change to a value of your choice default: 100
+            countTotal: true // set to true to receive total count in response
+        }
+    })
+    const providersResponse = await client.Providers(providersRequest);
+    const data = QueryProvidersResponse.toJSON(providersResponse);
+    
+    console.log(data)
+}
+
+main();


### PR DESCRIPTION
This PR adds basic examples to query provider data.

- List all providers
- Get details of a single provider
- Get lease status for a specific lease
