### PR TITLE
Mainnet6 bugfixes

### DIFF
--- a/src/sdl/types.ts
+++ b/src/sdl/types.ts
@@ -22,7 +22,7 @@ export type v2ManifestService = {
     Resources: ResourceUnits,
     Count: number
     Expose: v2ServiceExpose[],
-    params?: ServiceParams,
+    params?: v2ManifestServiceParams,
 }
 
 export type v3ManifestService = {
@@ -34,7 +34,7 @@ export type v3ManifestService = {
     resources: ResourceUnits,
     count: number
     expose: v3ServiceExpose[],
-    params: ServiceParams | null,
+    params: v3ManifestServiceParams | null,
 }
 
 export type v2ServiceExposeHttpOptions = {
@@ -83,8 +83,12 @@ export type v3ServiceExpose = {
     endpointSequenceNumber: number,
 }
 
-export type ServiceParams = {
+export type v2ManifestServiceParams = {
     Storage: v2ServiceStorageParams[],
+}
+
+export type v3ManifestServiceParams = {
+    storage: v2ServiceStorageParams[],
 }
 
 export type v2Sdl = {

--- a/tap-snapshots/tests/test_deployments.ts.test.cjs
+++ b/tap-snapshots/tests/test_deployments.ts.test.cjs
@@ -71,7 +71,7 @@ Object {
                   "amount": "100.000000000000000",
                   "denom": "uakt",
                 },
-                "resources": Object {
+                "resource": Object {
                   "cpu": Object {
                     "attributes": Array [],
                     "units": Object {
@@ -84,6 +84,13 @@ Object {
                       "sequenceNumber": 0,
                     },
                   ],
+                  "gpu": Object {
+                    "attributes": Array [],
+                    "units": Object {
+                      "val": "MA==",
+                    },
+                  },
+                  "id": 1,
                   "memory": Object {
                     "attributes": Array [],
                     "quantity": Object {
@@ -170,7 +177,7 @@ Object {
                   "amount": "1000.00000000000000",
                   "denom": "uakt",
                 },
-                "resources": Object {
+                "resource": Object {
                   "cpu": Object {
                     "attributes": Array [],
                     "units": Object {
@@ -183,6 +190,13 @@ Object {
                       "sequenceNumber": 0,
                     },
                   ],
+                  "gpu": Object {
+                    "attributes": Array [],
+                    "units": Object {
+                      "val": "MA==",
+                    },
+                  },
+                  "id": 1,
                   "memory": Object {
                     "attributes": Array [],
                     "quantity": Object {
@@ -269,7 +283,7 @@ Object {
                   "amount": "10000.0000000000000",
                   "denom": "uakt",
                 },
-                "resources": Object {
+                "resource": Object {
                   "cpu": Object {
                     "attributes": Array [],
                     "units": Object {
@@ -282,6 +296,13 @@ Object {
                       "sequenceNumber": 0,
                     },
                   ],
+                  "gpu": Object {
+                    "attributes": Array [],
+                    "units": Object {
+                      "val": "MA==",
+                    },
+                  },
+                  "id": 1,
                   "memory": Object {
                     "attributes": Array [],
                     "quantity": Object {
@@ -368,7 +389,7 @@ Object {
                   "amount": "1000.00000000000000",
                   "denom": "uakt",
                 },
-                "resources": Object {
+                "resource": Object {
                   "cpu": Object {
                     "attributes": Array [],
                     "units": Object {
@@ -381,6 +402,13 @@ Object {
                       "sequenceNumber": 0,
                     },
                   ],
+                  "gpu": Object {
+                    "attributes": Array [],
+                    "units": Object {
+                      "val": "MA==",
+                    },
+                  },
+                  "id": 1,
                   "memory": Object {
                     "attributes": Array [],
                     "quantity": Object {
@@ -467,7 +495,7 @@ Object {
                   "amount": "10000.0000000000000",
                   "denom": "uakt",
                 },
-                "resources": Object {
+                "resource": Object {
                   "cpu": Object {
                     "attributes": Array [],
                     "units": Object {
@@ -480,6 +508,13 @@ Object {
                       "sequenceNumber": 0,
                     },
                   ],
+                  "gpu": Object {
+                    "attributes": Array [],
+                    "units": Object {
+                      "val": "MA==",
+                    },
+                  },
+                  "id": 1,
                   "memory": Object {
                     "attributes": Array [],
                     "quantity": Object {
@@ -566,7 +601,7 @@ Object {
                   "amount": "1000.00000000000000",
                   "denom": "uakt",
                 },
-                "resources": Object {
+                "resource": Object {
                   "cpu": Object {
                     "attributes": Array [],
                     "units": Object {
@@ -579,6 +614,13 @@ Object {
                       "sequenceNumber": 0,
                     },
                   ],
+                  "gpu": Object {
+                    "attributes": Array [],
+                    "units": Object {
+                      "val": "MA==",
+                    },
+                  },
+                  "id": 1,
                   "memory": Object {
                     "attributes": Array [],
                     "quantity": Object {
@@ -674,7 +716,7 @@ Object {
               "amount": "100.000000000000000",
               "denom": "uakt",
             },
-            "resources": Object {
+            "resource": Object {
               "cpu": Object {
                 "attributes": Array [],
                 "units": Object {
@@ -687,6 +729,13 @@ Object {
                   "sequenceNumber": 0,
                 },
               ],
+              "gpu": Object {
+                "attributes": Array [],
+                "units": Object {
+                  "val": "MA==",
+                },
+              },
+              "id": 1,
               "memory": Object {
                 "attributes": Array [],
                 "quantity": Object {

--- a/tests/test_deployments.ts
+++ b/tests/test_deployments.ts
@@ -9,7 +9,7 @@ import {
   QueryDeploymentResponse,
   QueryDeploymentsRequest,
   QueryDeploymentsResponse,
-} from "../src/protobuf/akash/deployment/v1beta2/query";
+} from "../src/protobuf/akash/deployment/v1beta3/query";
 
 tap.test("Deployments: query deployment list with owner filter", async (t) => {
   t.plan(1);

--- a/tests/test_leases.ts
+++ b/tests/test_leases.ts
@@ -5,11 +5,8 @@ import { testSnap } from "./util";
 import { getRpc } from "../src/rpc";
 import {
     QueryClientImpl,
-    QueryLeaseRequest,
-    QueryLeaseResponse,
     QueryLeasesRequest,
-    QueryLeasesResponse,
-} from "../src/protobuf/akash/market/v1beta2/query";
+} from "../src/protobuf/akash/market/v1beta3/query";
 
 tap.test("Deployments: query lease escrow matches expected result", async (t) => {
     t.plan(1);


### PR DESCRIPTION
- Change `Storage` param to lowercase in beta3
- Return empty array instead of null if there is no endpoints
- Sort services by name
- Remove dirty fix that was switching `mount` & `readOnly` params since it would seem it is no longer needed
- Updated tests to beta3