### PR TITLE
fix: remove hardcoded is for resource profiles

### DIFF
--- a/tap-snapshots/tests/test_sdl_wordpress.ts.test.cjs
+++ b/tap-snapshots/tests/test_sdl_wordpress.ts.test.cjs
@@ -1,0 +1,43 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`tests/test_sdl_wordpress.ts TAP SDL: Wordpress Version > Manifest version matches expected result 1`] = `
+Uint8Array [
+  219,
+  108,
+  51,
+  117,
+  198,
+  203,
+  254,
+  23,
+  231,
+  87,
+  195,
+  36,
+  147,
+  215,
+  27,
+  25,
+  65,
+  116,
+  86,
+  242,
+  189,
+  131,
+  165,
+  98,
+  212,
+  63,
+  194,
+  233,
+  63,
+  64,
+  141,
+  48,
+]
+`

--- a/tests/fixtures/wordpress.manifest.json
+++ b/tests/fixtures/wordpress.manifest.json
@@ -1,0 +1,208 @@
+[
+  {
+    "name": "akash",
+    "services": [
+      {
+        "name": "db",
+        "image": "mariadb:10.6.4",
+        "command": null,
+        "args": null,
+        "env": [
+          "MYSQL_RANDOM_ROOT_PASSWORD=1",
+          "MYSQL_DATABASE=wordpress",
+          "MYSQL_USER=wordpress",
+          "MYSQL_PASSWORD=testpass4you"
+        ],
+        "resources": {
+          "id": 1,
+          "cpu": {
+            "units": {
+              "val": "1000"
+            }
+          },
+          "memory": {
+            "size": {
+              "val": "1073741824"
+            }
+          },
+          "storage": [
+            {
+              "name": "default",
+              "size": {
+                "val": "1073741824"
+              }
+            },
+            {
+              "name": "wordpress-db",
+              "size": {
+                "val": "8589934592"
+              },
+              "attributes": [
+                {
+                  "key": "class",
+                  "value": "beta3"
+                },
+                {
+                  "key": "persistent",
+                  "value": "true"
+                }
+              ]
+            }
+          ],
+          "gpu": {
+            "units": {
+              "val": "0"
+            }
+          },
+          "endpoints": []
+        },
+        "count": 1,
+        "expose": [
+          {
+            "port": 3306,
+            "externalPort": 0,
+            "proto": "TCP",
+            "service": "wordpress",
+            "global": false,
+            "hosts": null,
+            "httpOptions": {
+              "maxBodySize": 1048576,
+              "readTimeout": 60000,
+              "sendTimeout": 60000,
+              "nextTries": 3,
+              "nextTimeout": 0,
+              "nextCases": [
+                "error",
+                "timeout"
+              ]
+            },
+            "ip": "",
+            "endpointSequenceNumber": 0
+          },
+          {
+            "port": 33060,
+            "externalPort": 0,
+            "proto": "TCP",
+            "service": "wordpress",
+            "global": false,
+            "hosts": null,
+            "httpOptions": {
+              "maxBodySize": 1048576,
+              "readTimeout": 60000,
+              "sendTimeout": 60000,
+              "nextTries": 3,
+              "nextTimeout": 0,
+              "nextCases": [
+                "error",
+                "timeout"
+              ]
+            },
+            "ip": "",
+            "endpointSequenceNumber": 0
+          }
+        ],
+        "params": {
+          "storage": [
+            {
+              "name": "wordpress-db",
+              "mount": "/var/lib/mysql",
+              "readOnly": false
+            }
+          ]
+        }
+      },
+      {
+        "name": "wordpress",
+        "image": "wordpress",
+        "command": null,
+        "args": null,
+        "env": [
+          "WORDPRESS_DB_HOST=db",
+          "WORDPRESS_DB_USER=wordpress",
+          "WORDPRESS_DB_PASSWORD=testpass4you",
+          "WORDPRESS_DB_NAME=wordpress"
+        ],
+        "resources": {
+          "id": 2,
+          "cpu": {
+            "units": {
+              "val": "4000"
+            }
+          },
+          "memory": {
+            "size": {
+              "val": "4294967296"
+            }
+          },
+          "storage": [
+            {
+              "name": "default",
+              "size": {
+                "val": "4294967296"
+              }
+            },
+            {
+              "name": "wordpress-data",
+              "size": {
+                "val": "34359738368"
+              },
+              "attributes": [
+                {
+                  "key": "class",
+                  "value": "beta3"
+                },
+                {
+                  "key": "persistent",
+                  "value": "true"
+                }
+              ]
+            }
+          ],
+          "gpu": {
+            "units": {
+              "val": "0"
+            }
+          },
+          "endpoints": [
+            {
+              "sequence_number": 0
+            }
+          ]
+        },
+        "count": 1,
+        "expose": [
+          {
+            "port": 80,
+            "externalPort": 0,
+            "proto": "TCP",
+            "service": "",
+            "global": true,
+            "hosts": null,
+            "httpOptions": {
+              "maxBodySize": 104857600,
+              "readTimeout": 60000,
+              "sendTimeout": 60000,
+              "nextTries": 3,
+              "nextTimeout": 0,
+              "nextCases": [
+                "error",
+                "timeout"
+              ]
+            },
+            "ip": "",
+            "endpointSequenceNumber": 0
+          }
+        ],
+        "params": {
+          "storage": [
+            {
+              "name": "wordpress-data",
+              "mount": "/var/www/html",
+              "readOnly": false
+            }
+          ]
+        }
+      }
+    ]
+  }
+]

--- a/tests/fixtures/wordpress.sdl.yml
+++ b/tests/fixtures/wordpress.sdl.yml
@@ -1,0 +1,107 @@
+---
+version: '2.0'
+services:
+  wordpress:
+    image: wordpress
+    depends_on:
+    - db
+    expose:
+      - port: 80
+        http_options:
+          max_body_size: 104857600
+        # accept: 
+        # - "example.com"
+        to:
+          - global: true
+    env:
+      - WORDPRESS_DB_HOST=db
+      - WORDPRESS_DB_USER=wordpress
+      - WORDPRESS_DB_PASSWORD=testpass4you
+      - WORDPRESS_DB_NAME=wordpress
+    params:
+      storage:
+        wordpress-data:
+          mount: /var/www/html
+          readOnly: false
+  db:
+    # We use a mariadb image which supports both amd64 & arm64 architecture
+    image: mariadb:10.6.4
+    # If you really want to use MySQL, uncomment the following line
+    #image: mysql:8.0.27
+    expose:
+      - port: 3306
+        to:
+          - service: wordpress
+      - port: 33060
+        to:
+          - service: wordpress
+    env:
+      - MYSQL_RANDOM_ROOT_PASSWORD=1
+      - MYSQL_DATABASE=wordpress
+      - MYSQL_USER=wordpress
+      - MYSQL_PASSWORD=testpass4you
+    params:
+      storage:
+        wordpress-db:
+          mount: /var/lib/mysql
+          readOnly: false
+profiles:
+  compute:
+    wordpress:
+      resources:
+        gpu:
+          units: 0
+        cpu:
+          units: 4
+        memory:
+          size: 4Gi
+        storage:
+          - size: 4Gi
+          - name: wordpress-data
+            size: 32Gi
+            attributes:
+              persistent: true
+              class: beta3
+    db:
+      resources:
+        gpu:
+          units: 0
+        cpu:
+          units: 1
+        memory:
+          size: 1Gi
+        storage:
+          - size: 1Gi
+          - name: wordpress-db
+            size: 8Gi
+            attributes:
+              persistent: true
+              class: beta3
+  placement:
+    akash:
+      #######################################################
+      #Keep this section to deploy on trusted providers
+      signedBy:
+        anyOf:
+          - "akash1365yvmc4s7awdyj3n2sav7xfx76adc6dnmlx63"
+          - "akash18qa2a2ltfyvkyj0ggj3hkvuj6twzyumuaru9s4"
+      #######################################################
+      #Remove this section to deploy on untrusted providers
+      #Beware* You may have deployment, security, or other issues on untrusted providers
+      #https://docs.akash.network/providers/akash-audited-attributes
+      pricing:
+        wordpress:
+          denom: uakt
+          amount: 10000
+        db:
+          denom: uakt
+          amount: 10000
+deployment:
+  wordpress:
+    akash:
+      profile: wordpress
+      count: 1
+  db:
+    akash:
+      profile: db
+      count: 1

--- a/tests/test_sdl_wordpress.ts
+++ b/tests/test_sdl_wordpress.ts
@@ -1,0 +1,28 @@
+import tap from "tap";
+import fs from "fs";
+
+import { SDL } from '../src/sdl';
+
+const testSDL = fs.readFileSync('./tests/fixtures/wordpress.sdl.yml', 'utf8');
+
+const expectedManifest = JSON.parse(
+  fs.readFileSync('./tests/fixtures/wordpress.manifest.json', 'utf8')
+);
+
+tap.test("SDL: Wordpress Manifest", async (t) => {
+  t.plan(1);
+
+  const sdl = SDL.fromString(testSDL, 'beta3');
+  const result = sdl.manifestSorted();
+
+  t.same(result, expectedManifest, "Manifest matches expected result");
+});
+
+tap.test("SDL: Wordpress Version", async (t) => {
+  t.plan(1);
+
+  const sdl = SDL.fromString(testSDL, 'beta3');
+  const result = await sdl.manifestVersion();
+
+  t.matchSnapshot(result, "Manifest version matches expected result");
+});


### PR DESCRIPTION
Removes that hardcoded id for the profiles. This implementation is the 'naive' approach, and could have mis-matches with the deployment groups if there are multiple deployment placements.
