### PR TITLE
fix: sort services for deployment groups to ensure consistent ids

### DIFF
--- a/src/sdl/index.ts
+++ b/src/sdl/index.ts
@@ -671,8 +671,10 @@ export class SDL {
 
     v3Groups() {
         const groups = new Map<string, v3DeploymentGroup>();
+        const services = Object.entries(this.data.services)
+            .sort(([a], [b]) => a.localeCompare(b));
 
-        for (const [svcName, service] of Object.entries(this.data.services)) {
+        for (const [svcName, service] of services) {
             for (const [placementName, svcdepl] of Object.entries(this.data.deployment[svcName])) {
                 // objects below have been ensured to exist
                 const compute = this.data.profiles.compute[svcdepl.profile];

--- a/tap-snapshots/tests/test_sdl_wordpress.ts.test.cjs
+++ b/tap-snapshots/tests/test_sdl_wordpress.ts.test.cjs
@@ -5,6 +5,219 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
+exports[`tests/test_sdl_wordpress.ts TAP SDL: Wordpress Deployment Groups > Groups matches expected result 1`] = `
+Array [
+  Object {
+    "name": "akash",
+    "requirements": Object {
+      "attributes": Array [],
+      "signed_by": Object {
+        "all_of": Array [],
+        "any_of": Array [
+          "akash1365yvmc4s7awdyj3n2sav7xfx76adc6dnmlx63",
+          "akash18qa2a2ltfyvkyj0ggj3hkvuj6twzyumuaru9s4",
+        ],
+      },
+    },
+    "resources": Array [
+      Object {
+        "count": 1,
+        "price": Object {
+          "amount": "10000",
+          "denom": "uakt",
+        },
+        "resource": Object {
+          "cpu": Object {
+            "attributes": undefined,
+            "units": Object {
+              "val": Uint8Array [
+                49,
+                48,
+                48,
+                48,
+              ],
+            },
+          },
+          "endpoints": Array [],
+          "gpu": Object {
+            "attributes": undefined,
+            "units": Object {
+              "val": Uint8Array [
+                48,
+              ],
+            },
+          },
+          "id": 1,
+          "memory": Object {
+            "attributes": undefined,
+            "quantity": Object {
+              "val": Uint8Array [
+                49,
+                48,
+                55,
+                51,
+                55,
+                52,
+                49,
+                56,
+                50,
+                52,
+              ],
+            },
+          },
+          "storage": Array [
+            Object {
+              "attributes": undefined,
+              "name": "default",
+              "quantity": Object {
+                "val": Uint8Array [
+                  49,
+                  48,
+                  55,
+                  51,
+                  55,
+                  52,
+                  49,
+                  56,
+                  50,
+                  52,
+                ],
+              },
+            },
+            Object {
+              "attributes": Array [
+                Object {
+                  "key": "class",
+                  "value": "beta3",
+                },
+                Object {
+                  "key": "persistent",
+                  "value": "true",
+                },
+              ],
+              "name": "wordpress-db",
+              "quantity": Object {
+                "val": Uint8Array [
+                  56,
+                  53,
+                  56,
+                  57,
+                  57,
+                  51,
+                  52,
+                  53,
+                  57,
+                  50,
+                ],
+              },
+            },
+          ],
+        },
+      },
+      Object {
+        "count": 1,
+        "price": Object {
+          "amount": "10000",
+          "denom": "uakt",
+        },
+        "resource": Object {
+          "cpu": Object {
+            "attributes": undefined,
+            "units": Object {
+              "val": Uint8Array [
+                52,
+                48,
+                48,
+                48,
+              ],
+            },
+          },
+          "endpoints": Array [
+            Object {
+              "sequence_number": 0,
+            },
+          ],
+          "gpu": Object {
+            "attributes": undefined,
+            "units": Object {
+              "val": Uint8Array [
+                48,
+              ],
+            },
+          },
+          "id": 2,
+          "memory": Object {
+            "attributes": undefined,
+            "quantity": Object {
+              "val": Uint8Array [
+                52,
+                50,
+                57,
+                52,
+                57,
+                54,
+                55,
+                50,
+                57,
+                54,
+              ],
+            },
+          },
+          "storage": Array [
+            Object {
+              "attributes": undefined,
+              "name": "default",
+              "quantity": Object {
+                "val": Uint8Array [
+                  52,
+                  50,
+                  57,
+                  52,
+                  57,
+                  54,
+                  55,
+                  50,
+                  57,
+                  54,
+                ],
+              },
+            },
+            Object {
+              "attributes": Array [
+                Object {
+                  "key": "class",
+                  "value": "beta3",
+                },
+                Object {
+                  "key": "persistent",
+                  "value": "true",
+                },
+              ],
+              "name": "wordpress-data",
+              "quantity": Object {
+                "val": Uint8Array [
+                  51,
+                  52,
+                  51,
+                  53,
+                  57,
+                  55,
+                  51,
+                  56,
+                  51,
+                  54,
+                  56,
+                ],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  },
+]
+`
+
 exports[`tests/test_sdl_wordpress.ts TAP SDL: Wordpress Version > Manifest version matches expected result 1`] = `
 Uint8Array [
   219,

--- a/tests/test_sdl_wordpress.ts
+++ b/tests/test_sdl_wordpress.ts
@@ -18,6 +18,15 @@ tap.test("SDL: Wordpress Manifest", async (t) => {
   t.same(result, expectedManifest, "Manifest matches expected result");
 });
 
+tap.test("SDL: Wordpress Deployment Groups", async (t) => {
+  t.plan(1);
+
+  const sdl = SDL.fromString(testSDL, 'beta3');
+  const result = sdl.groups();
+
+  t.matchSnapshot(result, "Groups matches expected result");
+});
+
 tap.test("SDL: Wordpress Version", async (t) => {
   t.plan(1);
 


### PR DESCRIPTION
Sorts the services by name before generating the deployment groups -- this ensures they are mapped in the same order as the manifest generation and that the IDs will be consistent.
