### PR TITLE
Add "expose" sorting

### DIFF
--- a/src/sdl/index.ts
+++ b/src/sdl/index.ts
@@ -431,7 +431,14 @@ export class SDL {
                 endpointSequenceNumber: endpointSequenceNumbers[to.ip] || 0,
             }))
             : []
-        );
+        ).sort((a,b) => {
+            if(a.service != b.service) return a.service.localeCompare(b.service);
+            if(a.port != b.port) return a.port - b.port;
+            if(a.proto != b.proto) return a.proto.localeCompare(b.proto);
+            if(a.global != b.global) return a.global ? -1 : 1;
+
+            return 0;
+        });
     }
 
     v2ManifestServiceParams(params: v2ServiceParams): v2ManifestServiceParams | undefined {


### PR DESCRIPTION
Add sorting of "expose" in manifest based on code from [akash-api](https://github.com/akash-network/akash-api/blob/fed1855978ea13d4e29d07d02cd8c9bc1842e22d/go/manifest/v2beta2/serviceexposes.go#L21C46-L21C46)