### PR TITLE
fix: add required persistent attribute when using ram class storage

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,18 +1,6 @@
 {
-  "extends": [
-    "@commitlint/config-conventional"
-  ],
+  "extends": ["@commitlint/config-conventional"],
   "rules": {
-    "scope-enum": [
-      2,
-      "always",
-      [
-        "certificates",
-        "network",
-        "wallet",
-        "api",
-        "stargate"
-      ]
-    ]
+    "scope-enum": [2, "always", ["certificates", "network", "wallet", "api", "stargate"]]
   }
 }

--- a/package.json
+++ b/package.json
@@ -76,12 +76,6 @@
       "npm run test",
       "npm run lint:fix",
       "npm run format"
-    ],
-    "package.json": [
-      "sort-json package.json"
-    ],
-    "tsconfig.json": [
-      "sort-json tsconfig.json"
     ]
   },
   "main": "build/index.js",

--- a/tests/__snapshots__/sdl_persistent_storage_attributes.spec.ts.snap
+++ b/tests/__snapshots__/sdl_persistent_storage_attributes.spec.ts.snap
@@ -184,6 +184,10 @@ exports[`test sdl persistent storage SDL: Persistent Storage Manifest: SDL: Pers
                   "key": "class",
                   "value": "ram",
                 },
+                {
+                  "key": "persistent",
+                  "value": "false",
+                },
               ],
               "name": "shm",
               "size": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "target": "es2021" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', 'ES2021', or 'ESNEXT'. */,
     "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
     // "lib": [],                                   /* Specify library files to be included in the compilation. */
-    "allowJs": true                                 /* Allow javascript files to be compiled. */,
+    "allowJs": true /* Allow javascript files to be compiled. */,
     // "checkJs": true,                             /* Report errors in .js files. */
     // "jsx": "preserve",                           /* Specify JSX code generation: 'preserve', 'react-native', 'react', 'react-jsx' or 'react-jsxdev'. */
     "declaration": true /* Generates corresponding '.d.ts' file. */,
@@ -43,7 +43,7 @@
     // "noPropertyAccessFromIndexSignature": true,  /* Require undeclared properties from index signatures to use element accesses. */
 
     /* Module Resolution Options */
-    "moduleResolution": "Node16"                    /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */,
+    "moduleResolution": "Node16" /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */,
     // "baseUrl": "./",                             /* Base directory to resolve non-absolute module names. */
     // "paths": {},                                 /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                              /* List of root folders whose combined content represents the structure of the project at runtime. */


### PR DESCRIPTION
Currently when using storage with class "ram", the persistent attribute must be set to false. This change make sure to add the persistent attribute if it is missing. 

https://github.com/akash-network/cloudmos/issues/147