### PR TITLE
fix: prevent duplicate persistent attribute when using ram storage

### DIFF
--- a/src/sdl/index.ts
+++ b/src/sdl/index.ts
@@ -258,7 +258,7 @@ export class SDL {
 
     const pairs = Object.keys(attributes).map(key => ({ key, value: attributes[key].toString() }));
 
-    if (attributes.class === "ram" && !attributes.persistent) {
+    if (attributes.class === "ram" && !("persistent" in attributes)) {
       pairs.push({ key: "persistent", value: "false" });
     }
 

--- a/tests/__snapshots__/sdl_persistent_storage_attributes.spec.ts.snap
+++ b/tests/__snapshots__/sdl_persistent_storage_attributes.spec.ts.snap
@@ -194,6 +194,22 @@ exports[`test sdl persistent storage SDL: Persistent Storage Manifest: SDL: Pers
                 "val": 1073741824,
               },
             },
+            {
+              "attributes": [
+                {
+                  "key": "class",
+                  "value": "ram",
+                },
+                {
+                  "key": "persistent",
+                  "value": "false",
+                },
+              ],
+              "name": "shm2",
+              "size": {
+                "val": 1073741824,
+              },
+            },
           ],
         },
         "params": {

--- a/tests/fixtures/persistent_storage_valid.sdl.yml
+++ b/tests/fixtures/persistent_storage_valid.sdl.yml
@@ -79,6 +79,11 @@ profiles:
             size: 1Gi
             attributes:
               class: ram
+          - name: shm2
+            size: 1Gi
+            attributes:
+              class: ram
+              persistent: false
   placement:
     akash:
       #######################################################


### PR DESCRIPTION
The previous check was only preventing a duplicate attribute if `persistent` was `true`. If persistent was false it would still add a new persistent attribute causing a duplicate issue when sending to the provider.

This PR fixes the check to look for the attribute presence no matter it's value and adds a storage with `persistent: false` to the test SDL.